### PR TITLE
Fix various 2376540 fhu

### DIFF
--- a/outlook/src/taskpane/components/Leads/LeadList/LeadList.tsx
+++ b/outlook/src/taskpane/components/Leads/LeadList/LeadList.tsx
@@ -36,7 +36,7 @@ class LeadListCompact extends React.Component<LeadListProps, LeadListState> {
                 </div>
         
                 <div className='logicon' onClick={() => {this.props.log(lead.id)}}>
-                    {lead.logged ? <FontAwesomeIcon icon={faCheck}/> : <FontAwesomeIcon icon={faReply} flip='horizontal'/>}
+                    {lead.logged ? <FontAwesomeIcon title='Logged' icon={faCheck}/> : <FontAwesomeIcon title='Log mail in Odoo' icon={faReply} flip='horizontal'/>}
                 </div>
             </div>)
         }

--- a/outlook/src/taskpane/components/Leads/Leads.tsx
+++ b/outlook/src/taskpane/components/Leads/Leads.tsx
@@ -25,7 +25,7 @@ class Leads extends React.Component<LeadsProps, LeadsState> {
         };
     }
 
-    loadLeads = () => {
+    loadLeads = (refresh: boolean=false) => {
         const requestJson = {
             partner: this.context.partner.id,
             offset: this.leadOffset,
@@ -35,7 +35,10 @@ class Leads extends React.Component<LeadsProps, LeadsState> {
         this.context.addRequestCanceller(cancellableRequest.cancel);
         cancellableRequest.promise.then((response) => {
             const parsed = JSON.parse(response);
-            const leadsCopy = this.state.leads.map(lead => LeadData.copy(lead));
+            let leadsCopy = [];
+            if (!refresh) {
+                leadsCopy = this.state.leads.map(lead => LeadData.copy(lead));
+            }
             const newLeads = parsed.result.leads.map(l => {return LeadData.fromJSON(l);})
             const allLeads = leadsCopy.concat(newLeads)
             this.setState({leads: allLeads, loaded: true, showMore: newLeads.length === this.leadLimit})
@@ -90,7 +93,7 @@ class Leads extends React.Component<LeadsProps, LeadsState> {
     public render(): JSX.Element {
         // Modules are loaded asynchronously and crm is displayed before the partner is populated.
         if (this.state.loaded === false && this.context.partner.id !== -1) {
-            this.loadLeads();
+            this.loadLeads(true);
         }
 
         /*

--- a/outlook/src/taskpane/components/Login/Login.tsx
+++ b/outlook/src/taskpane/components/Login/Login.tsx
@@ -65,7 +65,6 @@ class Login extends React.Component<LoginProps, LoginState> {
         const loginURL = api.baseURL + api.loginPage + '?redirect=' + redirectToAuthPage;
 
         Office.context.ui.displayDialogAsync(api.addInBaseURL + '/dialog.html?dialogredir=' + loginURL, options , (asyncResult) => {
-            console.log(asyncResult);
             let dialog = asyncResult.value;
             dialog.addEventHandler(Office.EventType.DialogMessageReceived, (_arg) => {
                 dialog.close();


### PR DESCRIPTION
[FIX] Outlook: prevent displaying same leads multiple times

To reproduce, log in, display the extension with a client that has
at least one opportunity, log out, login again.
The same opportunity is now displayed several times.

Bug reported in the notes of the task 2376540.

[IMP] Outlook: add tooltip on button to log email button

Without a tooltip, it wasn't clear what this button was doing.

Asked in the notes of the task 2376540.